### PR TITLE
Fix for Settings Page not visible

### DIFF
--- a/JellyfinUpscalerPlugin.csproj
+++ b/JellyfinUpscalerPlugin.csproj
@@ -13,7 +13,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.11.6" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.11.6" >
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+    
+    <PackageReference Include="Jellyfin.Model" Version="10.11.6" >
+    <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
     <!-- Microsoft.Extensions and System.Text.Json provided transitively by Jellyfin.Controller -->
     
     <!-- AI & Machine Learning Libraries -->


### PR DESCRIPTION
I refer to issue https://github.com/Kuschel-code/JellyfinUpscalerPlugin/issues/30.

When installing the Plugin the Settings are not visible. I added that the Jellyfin.Controller and Jellyfin.Model packages exclude assets (see https://github.com/jellyfin/jellyfin-plugin-template/blob/master/README.md).

Then I recompiled everything using this command:  dotnet publish .\JellyfinUpscalerPlugin.sln /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary

For me this fixed the issue. Cheers! :3